### PR TITLE
Migrate home page to SwiftUI with new UI

### DIFF
--- a/MathGPT/Application/SceneDelegate.swift
+++ b/MathGPT/Application/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -15,43 +16,25 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
-       
-        let storyboard = UIStoryboard(name: "HomePage", bundle: nil)
-                guard let vc = storyboard.instantiateViewController(withIdentifier: "HomePage") as? HomePage else {
-                    fatalError("HomePage view controller not found in storyboard")
-                }
-                let window = UIWindow(windowScene: windowScene)
-                window.rootViewController = vc
-                self.window = window
-                window.makeKeyAndVisible()
+        let rootView = HomeView()
+        let hostingController = UIHostingController(rootView: rootView)
+        
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = hostingController
+        self.window = window
+        window.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
     }
-
-
-    
-
-
-
 }
 

--- a/MathGPT/Screens/Home/HomePage.swift
+++ b/MathGPT/Screens/Home/HomePage.swift
@@ -5,60 +5,173 @@
 //  Created by Aagontuk on 7/4/25.
 //
 
-import UIKit
+import SwiftUI
 
-class HomePage: UIViewController {
-    
-    @IBOutlet weak var btnScan: UIButton!{
-        didSet{
-            
-            btnScan.addTarget(self, action: #selector(scanButtonTapped), for: .touchUpInside)
-            
+struct HomeView: View {
+    struct ChatMessage: Identifiable, Hashable {
+        enum Sender {
+            case user
+            case assistant
+        }
+        let id: UUID = UUID()
+        let sender: Sender
+        let text: String?
+        let showsImageCard: Bool
+    }
+
+    @State private var composedMessageText: String = ""
+    @State private var messages: [ChatMessage] = [
+        .init(sender: .user, text: "Hello ! there", showsImageCard: false),
+        .init(sender: .assistant, text: "Hello there! How may I assist you today?", showsImageCard: false),
+        .init(sender: .user, text: "I want to learn how to solve a cubic equation? 1. Linear Equations:\n\n• Solve for x: 3x + 5 = 14\n  • Solution: x = 3\n• Solve for y: 2(y + 3) = 20\n  • Solution: y = 7\n• Solve for x: 4x + 7 = 2x + 12\n  • Solution: x = 2.5", showsImageCard: false),
+        .init(sender: .assistant, text: nil, showsImageCard: true)
+    ]
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color(.systemBackground).ignoresSafeArea()
+                VStack(spacing: 0) {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 16) {
+                            ForEach(messages) { message in
+                                if message.showsImageCard {
+                                    ImageCard()
+                                        .padding(.horizontal)
+                                } else {
+                                    ChatBubble(text: message.text ?? "", isFromUser: message.sender == .user)
+                                        .padding(.horizontal)
+                                }
+                            }
+                            Spacer(minLength: 8)
+                        }
+                        .padding(.top, 8)
+                    }
+
+                    Divider()
+
+                    InputBar(text: $composedMessageText, onSend: handleSendTapped, onMic: handleMicTapped)
+                        .padding(.horizontal)
+                        .padding(.vertical, 8)
+                        .background(.ultraThinMaterial)
+                }
+            }
+            .navigationBarTitle("RESULT", displayMode: .inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: handleBackTapped) {
+                        Image(systemName: "chevron.left")
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: handleShareTapped) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+
+    private func handleBackTapped() {}
+    private func handleShareTapped() {}
+    private func handleMicTapped() {}
+
+    private func handleSendTapped() {
+        let trimmed = composedMessageText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { return }
+        messages.append(.init(sender: .user, text: trimmed, showsImageCard: false))
+        composedMessageText = ""
+    }
+}
+
+// MARK: - Subviews
+
+struct ChatBubble: View {
+    let text: String
+    let isFromUser: Bool
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            if isFromUser == false {
+                Image(systemName: "person.crop.circle.fill")
+                    .font(.system(size: 28))
+                    .foregroundColor(.accentColor)
+            }
+
+            Text(text)
+                .font(.body)
+                .foregroundColor(isFromUser ? .white : .primary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(isFromUser ? Color.accentColor : Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .frame(maxWidth: .infinity, alignment: isFromUser ? .trailing : .leading)
+
+            if isFromUser {
+                Spacer(minLength: 0)
+                    .frame(width: 28)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: isFromUser ? .trailing : .leading)
+    }
+}
+
+struct ImageCard: View {
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+                .frame(maxWidth: .infinity)
+                .frame(height: 220)
+                .overlay(
+                    Image(systemName: "doc.text.image")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 96, height: 96)
+                        .foregroundColor(.secondary)
+                )
+
+            HStack(spacing: 8) {
+                Image(systemName: "camera.viewfinder")
+                Text("Math Scan")
+                    .fontWeight(.semibold)
+            }
+            .foregroundColor(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color.black.opacity(0.75))
+            .clipShape(Capsule())
+            .padding(12)
         }
     }
-    
-    @IBOutlet weak var btnAddImage: UIButton!{
-        didSet{
-            btnAddImage.addTarget(self, action:  #selector(btnAddImageTapped), for: .touchUpInside)
+}
+
+struct InputBar: View {
+    @Binding var text: String
+    var onSend: () -> Void
+    var onMic: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            TextField("How can I help?", text: $text, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(1...4)
+
+            Button(action: onMic) {
+                Image(systemName: "mic.fill")
+                    .padding(8)
+            }
+
+            Button(action: onSend) {
+                Image(systemName: "paperplane.fill")
+                    .padding(8)
+            }
+            .buttonStyle(.borderedProminent)
         }
     }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        print("Here home page calling")
-        
-        func getImageName(){
-            
-            var imageName: String?
-            
-            imageName = "image"
-            
-            print("Image name is \(imageName ?? "No image name")")
-            
-        }
-        
-        
+}
 
-        // Do any additional setup after loading the view.
-    }
-    
-  
-
-    @objc func scanButtonTapped() {
-        // Your action code here
-        print("Scan button was tapped")
-        
-        
-    }
-    
-    @objc func btnAddImageTapped() {
-        // Your action code here
-        print("Image add button was tapped")
-        
-        
-    }
-    
-
-
+#Preview {
+    HomeView()
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replaced the UIKit home page with a new SwiftUI `HomeView` to implement the requested MathGPT UI.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The new `HomeView` includes chat bubbles, an image card for "Math Scan", and a bottom input bar with mic and send buttons, as per the user's design request. The app's entry point was updated in `SceneDelegate` to load this new SwiftUI view.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fbf50aa-aedd-46ab-ade1-f4b7688119f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fbf50aa-aedd-46ab-ade1-f4b7688119f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

