### PR TITLE
Simulate api response with placeholder

### DIFF
--- a/MathGPT/Screens/Home/HomePage.swift
+++ b/MathGPT/Screens/Home/HomePage.swift
@@ -27,6 +27,19 @@ struct HomeView: View {
         .init(sender: .assistant, text: nil, showsImageCard: true)
     ]
 
+    private let fallbackReplies: [String] = [
+        "Here’s a random response while the API is being wired up.",
+        "Working on it... Here’s a placeholder answer.",
+        "This is a simulated reply. The real API response will appear here.",
+        "Got it! Responding with a temporary message.",
+        "Thanks for your message — here’s a random placeholder.",
+        "I’m a stub right now. Real answers coming soon.",
+        "Placeholder reply: your request has been received.",
+        "Simulated: I understand. Here’s something for now.",
+        "Here’s a random message — API integration pending.",
+        "Acknowledged. Returning a mock response."
+    ]
+
     var body: some View {
         NavigationView {
             ZStack {
@@ -94,8 +107,29 @@ struct HomeView: View {
     private func handleSendTapped() {
         let trimmed = composedMessageText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.isEmpty == false else { return }
+
         messages.append(.init(sender: .user, text: trimmed, showsImageCard: false))
+        let userMessage = trimmed
         composedMessageText = ""
+
+        simulateAssistantResponse(to: userMessage)
+    }
+
+    private func simulateAssistantResponse(to userMessage: String) {
+        // API integration point:
+        // Replace the simulated delay and random reply below with your real API call.
+        // Example:
+        // callYourAPI(with: userMessage) { resultText in
+        //     DispatchQueue.main.async {
+        //         self.messages.append(.init(sender: .assistant, text: resultText, showsImageCard: false))
+        //     }
+        // }
+
+        let randomDelay = Double.random(in: 0.6...1.4)
+        let replyText = fallbackReplies.randomElement() ?? "Okay."
+        DispatchQueue.main.asyncAfter(deadline: .now() + randomDelay) {
+            self.messages.append(.init(sender: .assistant, text: replyText, showsImageCard: false))
+        }
     }
 }
 


### PR DESCRIPTION
Implement a placeholder chat reply mechanism with random messages for `HomeView`.

This change addresses the user's request for a temporary chat response feature while the backend API is still under development. A clear comment is included to guide future API integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-1038877c-4dc1-4a82-8c7b-64f67b1639f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1038877c-4dc1-4a82-8c7b-64f67b1639f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

